### PR TITLE
Add support for out-of-tree builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 HOST_ARCH       ?= $(shell uname -m | sed -e s/arm.*/arm/ -e s/aarch64.*/arm64/)
 ARCH            ?= $(shell uname -m | sed -e s/arm.*/arm/ -e s/aarch64.*/arm64/)
 KERNEL_SRC_DIR  ?= /lib/modules/$(shell uname -r)/build
+BUILD_DIR       ?= $(PWD)
+_BUILD_DIR      ?= $(shell readlink -f $(BUILD_DIR))
 
 ifeq ($(ARCH), arm)
  ifneq ($(HOST_ARCH), arm)
@@ -16,8 +18,13 @@ endif
 obj-m := dtbocfg.o
 
 all:
-	make -C $(KERNEL_SRC_DIR) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) M=$(PWD) modules
+	@# If this is an out-of-tree build, we have to create an empty makefile in the build directory
+	@# (this is a hack to get around Makefile.modpost trying to include the makefile
+	@#  and failing since we're doing a split build by setting src= inside the main Makefile)
+	@( [[ "$(BUILD_DIR)" != "$(PWD)" ]] && (mkdir -p "$(BUILD_DIR)" && touch "$(BUILD_DIR)/Makefile") || true )
+
+	$(MAKE) -C $(KERNEL_SRC_DIR) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) M=$(_BUILD_DIR) src=$(PWD) modules
 
 clean:
-	make -C $(KERNEL_SRC_DIR) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) M=$(PWD) clean
+	$(MAKE) -C $(KERNEL_SRC_DIR) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) M=$(_BUILD_DIR) src=$(PWD) clean
 


### PR DESCRIPTION
This patch allows you to set the `BUILD_DIR` environment variable when running make, and all the build files will be placed in the specified directory.

If this environment variable isn't set, the behaviour will be the same as before, making an in-tree build.

This allows you  to easily compile against multiple kernels without having multiple copies of the code checked out.