### PR TITLE
[makefile] Allow buit-in compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ ARCH            ?= $(shell uname -m | sed -e s/arm.*/arm/ -e s/aarch64.*/arm64/)
 BUILD_DIR       ?= $(PWD)
 _BUILD_DIR      ?= $(shell readlink -f $(BUILD_DIR))
 
+CONFIG_OF_DTBOCFG ?= m
+
 ifdef KERNEL_SRC
   KERNEL_SRC_DIR  := $(KERNEL_SRC)
 else
@@ -20,7 +22,7 @@ ifeq ($(ARCH), arm64)
  endif
 endif
 
-obj-m := dtbocfg.o
+obj-$(CONFIG_OF_DTBOCFG) := dtbocfg.o
 
 all:
 	@# If this is an out-of-tree build, we have to create an empty makefile in the build directory

--- a/Readme.md
+++ b/Readme.md
@@ -41,7 +41,34 @@ When building a kernel, Device-Tree-Overlay option should be enabled.
 You can enable the option via `make menu_config` ---> `Device Drivers` ---> `Device Tree and Open Firmware support`
 ---> `Device Tree overlays`, or by manually addting `CONFIG_OF_OVERLAY=y` in `.config`.
 
-## Builiding dtbocfg
+## Builiding dtbocfg in-tree
+
+Clone the git repository in the `drivers/of/` directory in your kernel tree, and add the following in 
+`drivers/of/Kconfig`:
+
+````
+config OF_DTBOCFG
+	bool
+	help
+	  Enable configFS control of device tree at runtime
+````
+
+and in the `config OF_OVERLAY` block:
+
+````
+    select OF_DTBOCFG
+````
+
+Then in `drivers/of/Makefile`:
+
+````
+obj-$(CONFIG_OF_DTBOCFG) += dtbocfg/
+````
+
+Then you should be able to build the kernel with the module built-in, with the module auto-selected from the 
+`OF_OVERLAY` property.
+
+## Builiding dtbocfg as a module
 
 Clone the git repository, and run `make` after modifying it according to your environment.
 


### PR DESCRIPTION
Hello,
I haven't done a lot a kernel work, so I'm not sure this is the cleanest way to do that, but here you go.
The README modification should be self-explanatory, but in case, the goal is to be able to build this module in-tree