### PR TITLE
Fix of_overlay_fdt_apply arguments list to match 6.6.0+ kernel prototype

### DIFF
--- a/dtbocfg.c
+++ b/dtbocfg.c
@@ -65,7 +65,11 @@ static int dtbocfg_overlay_item_create(struct dtbocfg_overlay_item *overlay)
     {
         int ovcs_id = 0;
 
+#if (LINUX_VERSION_CODE >= 0x060600)
+        ret_val = of_overlay_fdt_apply(overlay->dtbo,overlay->dtbo_size, &ovcs_id, NULL);
+#else
         ret_val = of_overlay_fdt_apply(overlay->dtbo,overlay->dtbo_size, &ovcs_id);
+#endif
         if (ret_val != 0) {
             pr_err("%s: Failed to apply overlay (ret_val=%d)\n", __func__, ret_val);
             goto failed;


### PR DESCRIPTION
The Linux kernel version  6.6.0-rc1is out and of_overlay_fdt_apply change is in it.

We run highly continuous integration tests of our CTU CAN FD IP core

   https://canbus.pages.fel.cvut.cz/

and related drivers where dtbocfg is used (lot thanks for its availability).
The results for fully preemptive variant and mainline Linux kernel
are there

  https://canbus.pages.fel.cvut.cz/can-latester/

dtbocfg is compiled and run daily for both variants heads, so if some
problem/incompatibility occurs we will be quickly noticed.